### PR TITLE
Fix jq expression in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Minimal CLI client for xapi rpc calls.
 The ouptu is in json, so can be piped to `jq` or other json tools for further filtering.
 For example you can get the `uuid` and `name__label` of all the VMs with:
 ```bash
-xapirpc VM get_all_records | jq '.[]|select(is_a_template==false)|{uuid, name_label}'
+xapirpc VM get_all_records | jq '.[]|select(.is_a_template==false)|{uuid, name_label}'
 ```
 
 There are a few optional flags available to customise the usage:


### PR DESCRIPTION
The original one fails with this error:
jq: error: is_a_template/0 is not defined at <top-level>, line 1:
.[]|select(is_a_template==false)|{uuid, name_label}
jq: 1 compile error

Signed-off-by: István Szekeres <szekeres@iii.hu>